### PR TITLE
feat: Log proxy environment variables on APIConnectionError

### DIFF
--- a/agents/model_adapter.py
+++ b/agents/model_adapter.py
@@ -3,6 +3,7 @@ from openai import OpenAI, APIError, APIConnectionError, RateLimitError, Authent
 import requests
 import json
 import traceback
+import os
 
 class BaseModelAdapter(ABC):
     @abstractmethod
@@ -30,6 +31,9 @@ class OpenAIAdapter(BaseModelAdapter):
         except APIConnectionError as e:
             print(f"OpenAI API ConnectionError: Failed to connect to OpenAI at {self.client.base_url}. Error: {str(e)}")
             traceback.print_exc()
+            http_proxy = os.getenv('HTTP_PROXY')
+            https_proxy = os.getenv('HTTPS_PROXY')
+            print(f"Proxy Information: HTTP_PROXY='{http_proxy}' HTTPS_PROXY='{https_proxy}'")
             return None
         except RateLimitError as e:
             print(f"OpenAI API RateLimitError: Rate limit exceeded for {self.client.base_url}. Error: {str(e)}")


### PR DESCRIPTION
Adds logging to display HTTP_PROXY and HTTPS_PROXY environment variables when an openai.APIConnectionError occurs.

This is to help you diagnose proxy-related connection issues, such as the previously observed 'httpcore.ProxyError: 504 Gateway Time-out', by explicitly showing which proxy servers might be configured in the application's environment.