### PR TITLE
refactor: Make RateLimitError and AuthenticationError logs more concise

### DIFF
--- a/agents/model_adapter.py
+++ b/agents/model_adapter.py
@@ -37,11 +37,9 @@ class OpenAIAdapter(BaseModelAdapter):
             return None
         except RateLimitError as e:
             print(f"OpenAI API RateLimitError: Rate limit exceeded for {self.client.base_url}. Error: {str(e)}")
-            traceback.print_exc()
             return None
         except AuthenticationError as e:
             print(f"OpenAI API AuthenticationError: Authentication failed for {self.client.base_url}. Error: {str(e)}")
-            traceback.print_exc()
             return None
         except APIError as e: # Catch other OpenAI API errors
             print(f"OpenAI APIError: An API error occurred with {self.client.base_url}. Error: {str(e)}")


### PR DESCRIPTION
Reduces log verbosity for `openai.RateLimitError` and `openai.AuthenticationError` in `OpenAIAdapter.get_response` by removing the `traceback.print_exc()` call from their handlers.

The primary error message from `str(e)` is retained, as it typically provides sufficient information for these specific, well-understood error types. Full tracebacks are still printed for `APIConnectionError` and the generic `APIError` (and other unexpected exceptions) where more debugging context is usually required.

This addresses your feedback regarding excessive log output for these particular error conditions.