### PR TITLE
Fix: Improve OpenAI API error handling for 5xx errors

### DIFF
--- a/agents/model_adapter.py
+++ b/agents/model_adapter.py
@@ -12,7 +12,7 @@ class BaseModelAdapter(ABC):
         pass
 
 class OpenAIAdapter(BaseModelAdapter):
-    def __init__(self, api_key, base_url, model_name="deepseek-chat", request_timeout=60, max_retries=3, initial_backoff_seconds=1):
+    def __init__(self, api_key, base_url, model_name="deepseek-chat", request_timeout=120, max_retries=5, initial_backoff_seconds=2):
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.model_name = model_name
         self.request_timeout = request_timeout
@@ -151,9 +151,9 @@ def get_model_adapter(config):
             api_key=config.get("api_key"),
             base_url=config.get("base_url"),
             model_name=config.get("model_name", "deepseek-chat"),
-            request_timeout=config.get("request_timeout", 60),
-            max_retries=config.get("max_retries", 3),
-            initial_backoff_seconds=config.get("initial_backoff_seconds", 1)
+            request_timeout=config.get("request_timeout", 120),
+            max_retries=config.get("max_retries", 5),
+            initial_backoff_seconds=config.get("initial_backoff_seconds", 2)
         )
     elif model_type == "ollama":
         return OllamaAdapter(

--- a/config/settings.py
+++ b/config/settings.py
@@ -24,7 +24,10 @@ ACTIVE_MODEL_CONFIG = {
         "api_key": "sk-1234",  # 将这里替换为您的真实 OpenAI API Key
         #"base_url": os.getenv('OPENAI_BASE_URL', 'https://api.deepseek.com/'),
         "base_url": os.getenv('OPENAI_BASE_URL', 'http://api.openai.rnd.huawei.com'),
-        "default_model": "qwq-32b-128k"
+        "default_model": "qwq-32b-128k",
+        "request_timeout": 120,
+        "max_retries": 5,
+        "initial_backoff_seconds": 2
     },
     "ollama": {
         "base_url": os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434'),
@@ -39,4 +42,9 @@ MODEL_CONFIG = {
     "base_url": ACTIVE_MODEL_CONFIG.get(ACTIVE_MODEL_CONFIG["type"], {}).get("base_url"),
     "model_name": ACTIVE_MODEL_CONFIG.get(ACTIVE_MODEL_CONFIG["type"], {}).get("default_model")
 }
+
+if MODEL_CONFIG["type"] == "openai":
+    MODEL_CONFIG["request_timeout"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("request_timeout")
+    MODEL_CONFIG["max_retries"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("max_retries")
+    MODEL_CONFIG["initial_backoff_seconds"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("initial_backoff_seconds")
     


### PR DESCRIPTION
This commit addresses intermittent OpenAI API 504 Gateway Timeout errors by:

1. Making timeout and retry parameters configurable:
   - `request_timeout`, `max_retries`, and `initial_backoff_seconds` can now be set in `config/settings.py` for the OpenAI model.
   - These configurations are properly passed to the `OpenAIAdapter`.

2. Increasing default values:
   - The default `request_timeout` in `OpenAIAdapter` has been increased from 60s to 120s.
   - The default `max_retries` in `OpenAIAdapter` has been increased from 3 to 5.
   - The default `initial_backoff_seconds` in `OpenAIAdapter` is set to 2s.

These changes provide more resilience against transient server-side issues or network delays when communicating with the OpenAI API, and allow for easier tuning of these parameters without direct code modification.