### PR TITLE
Fix: Implement proxy authentication for OpenAI API calls

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,10 @@ ACTIVE_MODEL_CONFIG = {
         "default_model": "qwq-32b-128k",
         "request_timeout": 120,
         "max_retries": 5,
-        "initial_backoff_seconds": 2
+        "initial_backoff_seconds": 2,
+        "proxy_url": os.getenv('OPENAI_PROXY_URL', None),
+        "proxy_username": os.getenv('OPENAI_PROXY_USERNAME', None),
+        "proxy_password": os.getenv('OPENAI_PROXY_PASSWORD', None)
     },
     "ollama": {
         "base_url": os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434'),
@@ -47,4 +50,6 @@ if MODEL_CONFIG["type"] == "openai":
     MODEL_CONFIG["request_timeout"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("request_timeout")
     MODEL_CONFIG["max_retries"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("max_retries")
     MODEL_CONFIG["initial_backoff_seconds"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("initial_backoff_seconds")
-    
+    MODEL_CONFIG["proxy_url"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("proxy_url")
+    MODEL_CONFIG["proxy_username"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("proxy_username")
+    MODEL_CONFIG["proxy_password"] = ACTIVE_MODEL_CONFIG.get("openai", {}).get("proxy_password")


### PR DESCRIPTION
Addresses a 407 Proxy Authentication Required error when connecting to the OpenAI API via a proxy.

Changes include:
- Modified `OpenAIAdapter` in `agents/model_adapter.py` to accept proxy URL, username, and password.
- The `OpenAI` client within `OpenAIAdapter` is now configured with a custom `httpx.Client` that includes the necessary proxy authentication headers if proxy details are provided.
- Added proxy configuration options (`proxy_url`, `proxy_username`, `proxy_password`) to `config/settings.py`, loaded from environment variables (`OPENAI_PROXY_URL`, `OPENAI_PROXY_USERNAME`, `OPENAI_PROXY_PASSWORD`).
- Updated the `get_model_adapter` factory function to pass these proxy settings to the `OpenAIAdapter`.

This enables your application to successfully authenticate with and route OpenAI API requests through a proxy server requiring authentication.